### PR TITLE
add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repo is deprecated! Pulsar Edit will be moving to JSDoc to document the code
+
 # Joanna
 
 [![CI](https://github.com/atom/joanna/actions/workflows/ci.yml/badge.svg)](https://github.com/atom/joanna/actions/workflows/ci.yml)


### PR DESCRIPTION
This adds a message that joanna is deprecated since Pulsar Edit will be moving to JSDoc.